### PR TITLE
Updates fastify, plugin-meta

### DIFF
--- a/formbody.js
+++ b/formbody.js
@@ -49,5 +49,6 @@ function formBodyPlugin (fastify, options, next) {
 }
 
 module.exports = fp(formBodyPlugin, {
-  fastify: '>=0.38.0'
+  fastify: '>=0.39.1',
+  name: 'fastify-formbody'
 })

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-formbody#readme",
   "devDependencies": {
-    "fastify": "^0.38.0",
+    "fastify": "^0.39.1",
     "pre-commit": "^1.2.2",
     "request": "^2.81.0",
     "snazzy": "^7.0.0",


### PR DESCRIPTION
- Updates to fastify@0.39.1
- Adds `name` property to plugin-meta. see: https://github.com/fastify/fastify-plugin/issues/17#issuecomment-355972265