### PR TITLE
remove default plugin level bodyLimit

### DIFF
--- a/formbody.js
+++ b/formbody.js
@@ -3,13 +3,8 @@
 const fp = require('fastify-plugin')
 const qs = require('qs')
 
-const DEFAULT_BODY_LIMIT = 1024 * 1024 // 1 MiB
-const defaults = {
-  bodyLimit: DEFAULT_BODY_LIMIT
-}
-
 function formBodyPlugin (fastify, options, next) {
-  const opts = Object.assign({}, defaults, options || {})
+  const opts = Object.assign({}, options || {})
 
   function contentParser (req, body, done) {
     done(null, qs.parse(body.toString()))

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -110,7 +110,35 @@ test('cannot exceed body limit set on Fastify instance', (t) => {
   const fastify = Fastify({bodyLimit: 10})
 
   fastify
-    .register(plugin, {bodyLimit: undefined})
+    .register(plugin)
+    .post('/limited', (req, res) => {
+      res.send(Object.assign({}, req.body, {message: 'done'}))
+    })
+
+  fastify.listen(0, (err) => {
+    if (err) tap.error(err)
+    fastify.server.unref()
+
+    const reqOpts = {
+      method: 'POST',
+      baseUrl: 'http://localhost:' + fastify.server.address().port
+    }
+    const req = request.defaults(reqOpts)
+    const payload = require('crypto').randomBytes(128).toString('hex')
+    req({uri: '/limited', form: {foo: payload}}, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 413)
+      t.is(JSON.parse(body).message, 'Request body is too large')
+    })
+  })
+})
+
+test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
+  t.plan(3)
+  const fastify = Fastify({bodyLimit: 100000})
+
+  fastify
+    .register(plugin, {bodyLimit: 10})
     .post('/limited', (req, res) => {
       res.send(Object.assign({}, req.body, {message: 'done'}))
     })


### PR DESCRIPTION
remove plugin level bodyLimit, because fastify handle bodyLimit centrally. This will cause the plugin don't respect the fasify global bodyLimit.  