### PR TITLE
Multipart content type support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,10 @@ whatever is configured in
 [fastify](https://github.com/fastify/fastify/blob/master/docs/Factory.md#bodylimit)
  (`1048576` by default).
 
++ `multipart`: provides settings for the multipart content type, this would include
+`onlyBuffer` (defaults to true) which would only provide the buffer to the body, otherwise
+the buffer and filename are provided. Additionally, [Busboy](https://github.com/mscdex/busboy#busboy-methods) settings can be applied here
+
 ## License
 
 Licensed under [MIT](./LICENSE)

--- a/formbody.d.ts
+++ b/formbody.d.ts
@@ -3,7 +3,11 @@ import * as fastify from 'fastify'
 
 declare namespace formBodyPlugin {
   interface FormBodyPluginOptions {
-    bodyLimit?: number
+    bodyLimit?: number,
+    multipart?: {
+      onlyBuffer?: boolean,
+      limits?: any
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-formbody",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A module for Fastify to parse x-www-form-urlencoded bodies",
   "main": "formbody.js",
   "scripts": {
@@ -40,6 +40,7 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
+    "busboy": "^0.3.0",
     "fastify-plugin": "^1.0.0",
     "qs": "^6.5.1"
   },


### PR DESCRIPTION
Adding basic multipart content type support.

See https://github.com/fastify/fastify-swagger/issues/47 for details.