### PR TITLE
replace qs lib with node built-in querystring.parse by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,13 +52,34 @@ The sent reply would be the object:
 
 The plugin accepts an options object with the following properties:
 
-+ `bodyLimit`: the maximum amount of bytes to process
++ `bodyLimit`: The maximum amount of bytes to process
 before returning an error. If the limit is exceeded, a `500` error will be
 returned immediately. When set to `undefined` the limit will be set to whatever
 is configured on the parent Fastify instance. The default value is
 whatever is configured in
 [fastify](https://github.com/fastify/fastify/blob/master/docs/Factory.md#bodylimit)
  (`1048576` by default).
++ `parser`: The default parser used is the querystring.parse built-in.  You can change this default by passing a parser function e.g. `fastify.register(require('fastify-formbody'), { parser: str => myParser(str) })`
+
+## Upgrading from 4.x
+
+Previously, the external [qs lib](https://github.com/ljharb/qs) was used that did things like parse nested objects. For example:
+
+- ***Input:*** `foo[one]=foo&foo[two]=bar`
+- ***Parsed:*** `{ foo: { one: 'foo', two: 'bar' } }`
+
+The way this is handled now using the built-in querystring.parse:
+
+- ***Input:*** `foo[one]=foo&foo[two]=bar`
+- ***Parsed:*** `{ 'foo[one]': 'foo', 'foo[two]': 'bar' }`
+
+If you need nested parsing, you must configure it manually by installing the qs lib (`npm i qs`), and then configure an optional parser:
+
+```js
+const fastify = require('fastify')()
+const qs = require('qs')
+fastify.register(require('fastify-formbody'), { parser: str => qs.parse(str) })
+```
 
 ## License
 

--- a/formbody.js
+++ b/formbody.js
@@ -1,13 +1,21 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const qs = require('qs')
+const { parse } = require('querystring')
+
+function defaultParser (str) {
+  return parse(str)
+}
 
 function formBodyPlugin (fastify, options, next) {
-  const opts = Object.assign({}, options)
+  const opts = Object.assign({ parser: defaultParser }, options)
+  if (typeof opts.parser !== 'function') {
+    next(new Error('parser must be a function'))
+    return
+  }
 
   function contentParser (req, body, done) {
-    done(null, qs.parse(body.toString()))
+    done(null, opts.parser(body.toString()))
   }
 
   fastify.addContentTypeParser(

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "codecov": "^3.1.0",
     "fastify": "^3.0.0",
     "pre-commit": "^1.2.2",
+    "qs": "^6.5.1",
     "request": "^2.88.0",
     "snazzy": "^8.0.0",
     "standard": "^14.0.2",
@@ -42,8 +43,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "fastify-plugin": "^2.0.0",
-    "qs": "^6.5.1"
+    "fastify-plugin": "^2.0.0"
   },
   "types": "formbody.d.ts"
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -5,6 +5,7 @@ const test = tap.test
 const Fastify = require('fastify')
 const request = require('request')
 const plugin = require('../')
+const qs = require('qs')
 
 test('succes route succeeds', (t) => {
   t.plan(3)
@@ -152,6 +153,70 @@ test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
       t.error(err)
       t.strictEqual(response.statusCode, 413)
       t.is(JSON.parse(body).message, 'Request body is too large')
+    })
+  })
+})
+
+test('plugin should throw if opts.parser is not a function', (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.register(plugin, { parser: 'invalid' })
+  fastify.listen(0, (err) => {
+    t.ok(err)
+    t.match(err.message, /parser must be a function/)
+    fastify.server.unref()
+  })
+})
+
+test('plugin should not parse nested objects by default', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(plugin)
+  fastify.post('/test1', (req, res) => {
+    res.send(Object.assign({}, req.body, { message: 'done' }))
+  })
+
+  fastify.listen(0, (err) => {
+    if (err) tap.error(err)
+    fastify.server.unref()
+
+    const reqOpts = {
+      method: 'POST',
+      baseUrl: 'http://localhost:' + fastify.server.address().port
+    }
+    const req = request.defaults(reqOpts)
+    req({ uri: '/test1', form: { 'foo[one]': 'foo', 'foo[two]': 'bar' } }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { 'foo[one]': 'foo', 'foo[two]': 'bar', message: 'done' })
+    })
+  })
+})
+
+test('plugin should allow providing custom parser as option', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  // this makes sure existing users for <= 4 have upgrade path
+  fastify.register(plugin, { parser: str => qs.parse(str) })
+  fastify.post('/test1', (req, res) => {
+    res.send(Object.assign({}, req.body, { message: 'done' }))
+  })
+
+  fastify.listen(0, (err) => {
+    if (err) tap.error(err)
+    fastify.server.unref()
+
+    const reqOpts = {
+      method: 'POST',
+      baseUrl: 'http://localhost:' + fastify.server.address().port
+    }
+    const req = request.defaults(reqOpts)
+    req({ uri: '/test1', form: { 'foo[one]': 'foo', 'foo[two]': 'bar' } }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { foo: { one: 'foo', two: 'bar' }, message: 'done' })
     })
   })
 })


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and ~~`npm run benchmark`~~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This adds #50