### PR TITLE
test: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -41,7 +41,7 @@ test('cannot exceed body limit', (t) => {
     if (err) tap.error(err)
     fastify.server.unref()
 
-    const payload = require('crypto').randomBytes(128).toString('hex')
+    const payload = require('node:crypto').randomBytes(128).toString('hex')
     fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
       t.error(err)
       t.equal(response.statusCode, 413)
@@ -71,7 +71,7 @@ test('cannot exceed body limit when Content-Length is not available', (t) => {
     fastify.server.unref()
 
     let sent = false
-    const payload = require('stream').Readable({
+    const payload = require('node:stream').Readable({
       read: function () {
         this.push(sent ? null : Buffer.alloc(70000, 'a'))
         sent = true
@@ -98,7 +98,7 @@ test('cannot exceed body limit set on Fastify instance', (t) => {
     if (err) tap.error(err)
     fastify.server.unref()
 
-    const payload = require('crypto').randomBytes(128).toString('hex')
+    const payload = require('node:crypto').randomBytes(128).toString('hex')
     fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
       t.error(err)
       t.equal(response.statusCode, 413)
@@ -120,7 +120,7 @@ test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
     if (err) tap.error(err)
     fastify.server.unref()
 
-    const payload = require('crypto').randomBytes(128).toString('hex')
+    const payload = require('node:crypto').randomBytes(128).toString('hex')
     fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
       t.error(err)
       t.equal(response.statusCode, 413)


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
