### PR TITLE
chore: migrate to node:test with c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "codecov": "codecov",
     "lint": "standard | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 node --test",
     "test:typescript": "tsd"
   },
   "precommit": [
@@ -37,7 +37,7 @@
     "qs": "^6.12.0",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "tap": "^18.7.1",
+    "c8": "^7.12.0",
     "tsd": "^0.31.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "codecov": "codecov",
     "lint": "standard | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "c8 node --test",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "precommit": [
@@ -37,7 +37,7 @@
     "qs": "^6.12.0",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "c8": "^7.12.0",
+    "c8": "^10.1.2",
     "tsd": "^0.31.0"
   },
   "dependencies": {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const tap = require('tap')
-const test = tap.test
+const test = require('node:test')
 const Fastify = require('fastify')
 const plugin = require('../')
 const qs = require('qs')
 const formAutoContent = require('form-auto-content')
 
 test('succes route succeeds', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify()
 
   fastify.register(plugin)
@@ -17,19 +16,19 @@ test('succes route succeeds', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)
     fastify.server.unref()
 
     fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ foo: 'foo' }) }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(response.body), { foo: 'foo', message: 'done' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(response.body), { foo: 'foo', message: 'done' })
     })
   })
 })
 
 test('cannot exceed body limit', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify()
 
   fastify.register(plugin, { bodyLimit: 10 })
@@ -38,25 +37,25 @@ test('cannot exceed body limit', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)
     fastify.server.unref()
 
     const payload = require('node:crypto').randomBytes(128).toString('hex')
     fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 413)
-      t.equal(JSON.parse(response.body).message, 'Request body is too large')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 413)
+      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
     })
   })
 })
 
 test('cannot exceed body limit when Content-Length is not available', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify()
 
   fastify.addHook('onSend', (request, reply, payload, next) => {
     reply.send = function mockSend (arg) {
-      t.fail('reply.send() was called multiple times')
+      t.assert.fail('reply.send() was called multiple times')
     }
     setTimeout(next, 1)
   })
@@ -67,7 +66,7 @@ test('cannot exceed body limit when Content-Length is not available', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)
     fastify.server.unref()
 
     let sent = false
@@ -78,15 +77,15 @@ test('cannot exceed body limit when Content-Length is not available', (t) => {
       }
     })
     fastify.inject({ path: '/limited', method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: payload }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 413)
-      t.equal(JSON.parse(response.body).message, 'Request body is too large')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 413)
+      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
     })
   })
 })
 
 test('cannot exceed body limit set on Fastify instance', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify({ bodyLimit: 10 })
 
   fastify.register(plugin)
@@ -95,20 +94,20 @@ test('cannot exceed body limit set on Fastify instance', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)
     fastify.server.unref()
 
     const payload = require('node:crypto').randomBytes(128).toString('hex')
     fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 413)
-      t.equal(JSON.parse(response.body).message, 'Request body is too large')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 413)
+      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
     })
   })
 })
 
 test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify({ bodyLimit: 100000 })
 
   fastify.register(plugin, { bodyLimit: 10 })
@@ -117,31 +116,31 @@ test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)
     fastify.server.unref()
 
     const payload = require('node:crypto').randomBytes(128).toString('hex')
     fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 413)
-      t.equal(JSON.parse(response.body).message, 'Request body is too large')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 413)
+      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
     })
   })
 })
 
 test('plugin should throw if opts.parser is not a function', (t) => {
-  t.plan(2)
+  // t.plan(2)
   const fastify = Fastify()
   fastify.register(plugin, { parser: 'invalid' })
   fastify.listen({ port: 0 }, (err) => {
-    t.ok(err)
-    t.match(err.message, /parser must be a function/)
+    t.assert.ok(err)
+    t.assert.match(err.message, /parser must be a function/)
     fastify.server.unref()
   })
 })
 
 test('plugin should not parse nested objects by default', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify()
 
   fastify.register(plugin)
@@ -150,19 +149,19 @@ test('plugin should not parse nested objects by default', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)
     fastify.server.unref()
 
     fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' }) }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(response.body), { 'foo[one]': 'foo', 'foo[two]': 'bar', message: 'done' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(response.body), { 'foo[one]': 'foo', 'foo[two]': 'bar', message: 'done' })
     })
   })
 })
 
 test('plugin should allow providing custom parser as option', (t) => {
-  t.plan(3)
+  // t.plan(3)
   const fastify = Fastify()
 
   // this makes sure existing users for <= 4 have upgrade path
@@ -172,13 +171,13 @@ test('plugin should allow providing custom parser as option', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    if (err) tap.error(err)
+    t.assert.ifError(err)  // First assertion for checking error from `fastify.listen`
     fastify.server.unref()
 
     fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' }) }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(response.body), { foo: { one: 'foo', two: 'bar' }, message: 'done' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(response.body), { foo: { one: 'foo', two: 'bar' }, message: 'done' })
     })
   })
 })

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -7,7 +7,6 @@ const qs = require('qs')
 const formAutoContent = require('form-auto-content')
 
 test('success route succeeds', async (t) => {
-  t.plan(3)
   const fastify = Fastify()
 
   await fastify.register(plugin)
@@ -29,7 +28,6 @@ test('success route succeeds', async (t) => {
 })
 
 test('cannot exceed body limit', async (t) => {
-  t.plan(3)
   const fastify = Fastify()
 
   await fastify.register(plugin, { bodyLimit: 10 })
@@ -52,7 +50,6 @@ test('cannot exceed body limit', async (t) => {
 })
 
 test('cannot exceed body limit when Content-Length is not available', async (t) => {
-  t.plan(3)
   const fastify = Fastify()
 
   fastify.addHook('onSend', (request, reply, payload, next) => {
@@ -90,7 +87,6 @@ test('cannot exceed body limit when Content-Length is not available', async (t) 
 })
 
 test('cannot exceed body limit set on Fastify instance', async (t) => {
-  t.plan(3)
   const fastify = Fastify({ bodyLimit: 10 })
 
   await fastify.register(plugin)
@@ -113,8 +109,6 @@ test('cannot exceed body limit set on Fastify instance', async (t) => {
 })
 
 test('plugin bodyLimit should overwrite Fastify instance bodyLimit', async (t) => {
-  t.plan(3)
-
   const fastify = Fastify({ bodyLimit: 100000 })
 
   fastify.register(plugin, { bodyLimit: 10 })
@@ -137,7 +131,6 @@ test('plugin bodyLimit should overwrite Fastify instance bodyLimit', async (t) =
 })
 
 test('plugin should throw if opts.parser is not a function', async (t) => {
-  t.plan(2)
   const fastify = Fastify()
   try {
     await fastify.register(plugin, { parser: 'invalid' })
@@ -151,7 +144,6 @@ test('plugin should throw if opts.parser is not a function', async (t) => {
 })
 
 test('plugin should not parse nested objects by default', async (t) => {
-  t.plan(3)
   const fastify = Fastify()
 
   fastify.register(plugin)
@@ -173,7 +165,6 @@ test('plugin should not parse nested objects by default', async (t) => {
 })
 
 test('plugin should allow providing custom parser as option', async (t) => {
-  t.plan(3)
   const fastify = Fastify()
 
   // this makes sure existing users for <= 4 have upgrade path

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -171,7 +171,7 @@ test('plugin should allow providing custom parser as option', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)  // First assertion for checking error from `fastify.listen`
+    t.assert.ifError(err) // First assertion for checking error from `fastify.listen`
     fastify.server.unref()
 
     fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' }) }, (err, response) => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -6,51 +6,53 @@ const plugin = require('../')
 const qs = require('qs')
 const formAutoContent = require('form-auto-content')
 
-test('succes route succeeds', (t) => {
-  // t.plan(3)
+test('success route succeeds', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(plugin)
+  await fastify.register(plugin)
   fastify.post('/test1', (req, res) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ foo: 'foo' }) }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(response.body), { foo: 'foo', message: 'done' })
-    })
+  const response = await fastify.inject({
+    path: '/test1',
+    method: 'POST',
+    ...formAutoContent({ foo: 'foo' })
   })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.body), { foo: 'foo', message: 'done' })
 })
 
-test('cannot exceed body limit', (t) => {
-  // t.plan(3)
+test('cannot exceed body limit', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(plugin, { bodyLimit: 10 })
+  await fastify.register(plugin, { bodyLimit: 10 })
   fastify.post('/limited', (req, res) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    const payload = require('node:crypto').randomBytes(128).toString('hex')
-    fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 413)
-      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
-    })
+  const payload = require('node:crypto').randomBytes(128).toString('hex')
+  const response = await fastify.inject({
+    path: '/limited',
+    method: 'POST',
+    ...formAutoContent({ foo: payload })
   })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 413)
+  t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
 })
 
-test('cannot exceed body limit when Content-Length is not available', (t) => {
-  // t.plan(3)
+test('cannot exceed body limit when Content-Length is not available', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.addHook('onSend', (request, reply, payload, next) => {
@@ -60,54 +62,59 @@ test('cannot exceed body limit when Content-Length is not available', (t) => {
     setTimeout(next, 1)
   })
 
-  fastify.register(plugin, { bodyLimit: 10 })
+  await fastify.register(plugin, { bodyLimit: 10 })
   fastify.post('/limited', (req, res) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    let sent = false
-    const payload = require('node:stream').Readable({
-      read: function () {
-        this.push(sent ? null : Buffer.alloc(70000, 'a'))
-        sent = true
-      }
-    })
-    fastify.inject({ path: '/limited', method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: payload }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 413)
-      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
-    })
+  let sent = false
+  const payload = require('node:stream').Readable({
+    read: function () {
+      this.push(sent ? null : Buffer.alloc(70000, 'a'))
+      sent = true
+    }
   })
+
+  const response = await fastify.inject({
+    path: '/limited',
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: payload
+  })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 413)
+  t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
 })
 
-test('cannot exceed body limit set on Fastify instance', (t) => {
-  // t.plan(3)
+test('cannot exceed body limit set on Fastify instance', async (t) => {
+  t.plan(3)
   const fastify = Fastify({ bodyLimit: 10 })
 
-  fastify.register(plugin)
+  await fastify.register(plugin)
   fastify.post('/limited', (req, res) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    const payload = require('node:crypto').randomBytes(128).toString('hex')
-    fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 413)
-      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
-    })
+  const payload = require('node:crypto').randomBytes(128).toString('hex')
+  const response = await fastify.inject({
+    path: '/limited',
+    method: 'POST',
+    ...formAutoContent({ foo: payload })
   })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 413)
+  t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
 })
 
-test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
-  // t.plan(3)
+test('plugin bodyLimit should overwrite Fastify instance bodyLimit', async (t) => {
+  t.plan(3)
+
   const fastify = Fastify({ bodyLimit: 100000 })
 
   fastify.register(plugin, { bodyLimit: 10 })
@@ -115,32 +122,36 @@ test('plugin bodyLimit should overwrite Fastify instance bodyLimit', (t) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    const payload = require('node:crypto').randomBytes(128).toString('hex')
-    fastify.inject({ path: '/limited', method: 'POST', ...formAutoContent({ foo: payload }) }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 413)
-      t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
-    })
+  const payload = require('node:crypto').randomBytes(128).toString('hex')
+  const response = await fastify.inject({
+    path: '/limited',
+    method: 'POST',
+    ...formAutoContent({ foo: payload })
   })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 413)
+  t.assert.strictEqual(JSON.parse(response.body).message, 'Request body is too large')
 })
 
-test('plugin should throw if opts.parser is not a function', (t) => {
-  // t.plan(2)
+test('plugin should throw if opts.parser is not a function', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
-  fastify.register(plugin, { parser: 'invalid' })
-  fastify.listen({ port: 0 }, (err) => {
+  try {
+    await fastify.register(plugin, { parser: 'invalid' })
+    await fastify.listen({ port: 0 })
+  } catch (err) {
     t.assert.ok(err)
     t.assert.match(err.message, /parser must be a function/)
+  } finally {
     fastify.server.unref()
-  })
+  }
 })
 
-test('plugin should not parse nested objects by default', (t) => {
-  // t.plan(3)
+test('plugin should not parse nested objects by default', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.register(plugin)
@@ -148,20 +159,21 @@ test('plugin should not parse nested objects by default', (t) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' }) }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(response.body), { 'foo[one]': 'foo', 'foo[two]': 'bar', message: 'done' })
-    })
+  const response = await fastify.inject({
+    path: '/test1',
+    method: 'POST',
+    ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' })
   })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.body), { 'foo[one]': 'foo', 'foo[two]': 'bar', message: 'done' })
 })
 
-test('plugin should allow providing custom parser as option', (t) => {
-  // t.plan(3)
+test('plugin should allow providing custom parser as option', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
   // this makes sure existing users for <= 4 have upgrade path
@@ -170,14 +182,15 @@ test('plugin should allow providing custom parser as option', (t) => {
     res.send(Object.assign({}, req.body, { message: 'done' }))
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err) // First assertion for checking error from `fastify.listen`
-    fastify.server.unref()
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
 
-    fastify.inject({ path: '/test1', method: 'POST', ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' }) }, (err, response) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(response.body), { foo: { one: 'foo', two: 'bar' }, message: 'done' })
-    })
+  const response = await fastify.inject({
+    path: '/test1',
+    method: 'POST',
+    ...formAutoContent({ 'foo[one]': 'foo', 'foo[two]': 'bar' })
   })
+  t.assert.ifError(response.error)
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.body), { foo: { one: 'foo', two: 'bar' }, message: 'done' })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR replaces tap with node:test and introduces c8 for code coverage.

# Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
