### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # @fastify/formbody
 
-![CI](https://github.com/fastify/fastify-formbody/workflows/CI/badge.svg)
+[![CI](https://github.com/fastify/fastify-formbody/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/fastify/fastify-formbody/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/formbody.svg?style=flat)](https://www.npmjs.com/package/@fastify/formbody)
 [![NPM downloads](https://img.shields.io/npm/dm/fastify-formbody.svg?style=flat)](https://www.npmjs.com/package/@fastify/formbody)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge