### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/formbody.test-d.ts
+++ b/types/formbody.test-d.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify'
-import querystring from 'querystring'
+import querystring from 'node:querystring'
 import { expectDeprecated, expectError, expectType } from 'tsd'
 import formBodyPlugin, { FastifyFormbodyOptions, FormBodyPluginOptions } from '..'
 


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.