### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/fastify/fastify-formbody.git"
+    "url": "git+https://github.com/fastify/fastify-formbody.git"
   },
   "keywords": [
     "fastify",


### PR DESCRIPTION
## Summary
- replace the SSH-only repository URL with a public HTTPS Git URL
- keep npm repository metadata usable without GitHub SSH credentials

## Verification
- unit tests: 8 passed with 100% statement, branch, function, and line coverage
- TSTyche: 1 target and 2 assertions passed
- ESLint
- `pnpm pack --dry-run --json`
- direct package metadata assertion
- `git diff --check`